### PR TITLE
Without elec window

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Download the [Qtum client](https://github.com/qtumproject/qtum/releases) for the
 
 3. `npm run install-dep`
 
-4. `npm start`
+4. To start services either:
+
+	`npm start` // starts API, sync
+	or
+	`npm run start-elec` // start API, sync, launch UI (static built files in ui/ folder)
 
 5. App at `127.0.0.1:5555` or GraphiQL at `127.0.0.1:5555/graphiql`
 

--- a/main.js
+++ b/main.js
@@ -60,9 +60,14 @@ ipcMain.on('log-error', (event, arg) => {
 // This method will be called when Electron has finished initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
-  createWindow();
-
   server = require('./src/index');
+
+  // If --noelec flag is supplied, don't open any Electron windows
+  if (_.includes(process.argv, '--noelec')) {
+    return;
+  }
+
+  createWindow();
   server.emitter.once('qtumd-started', () => {
     uiWin.reload();
   });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "install-dep": "npm install && ./node_modules/.bin/yarn install",
-    "start": "./node_modules/.bin/electron . --qtumpath=./qtum/mac/bin --dev",
+    "start": "./node_modules/.bin/electron . --qtumpath=./qtum/mac/bin --dev --noelec",
+    "start-elec": "./node_modules/.bin/electron . --qtumpath=./qtum/mac/bin --dev",
     "test": "mocha --recursive src/test/.",
     "lint:fix": "eslint --fix -- src/.",
     "build:mac": "./node_modules/.bin/electron-builder build -m",


### PR DESCRIPTION
`npm start` to run api/sync without UI window for dev purposes. This requires you to run UI separately.

`npm run start-elec` to run api/sync/ui. UI will be from static built files in `ui` folder. For testing out Electron build before deployment.