### PR TITLE
Add txid to filter definitions

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -99,15 +99,16 @@ type Query {
 
 input TopicFilter {
   OR: [TopicFilter!]
+  txid: String
   address: String
   status: _OracleStatusType
 }
 
 input OracleFilter {
   OR: [OracleFilter!]
+  txid: String
   address: String
   topicAddress: String
-  resultSetterAddress: String
   resultSetterQAddress: String
   status: _OracleStatusType
   token: _TokenType


### PR DESCRIPTION
Need this to query Topics and Oracles by `txid`, which is necessary for mutated ones.