### PR TITLE
add syncPercent, address balance in /syncinfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,29 +10,13 @@
       "integrity": "sha512-juYJNi8JEpTUWXwz8ssa8Oop4n/kwJ/pIQP22vJAVAe6RTRD+0m+e9LRNnfK2EDaX8uwmUzLNGviFQRD6SxeOw==",
       "dev": true,
       "requires": {
-        "7zip-bin-linux": "1.3.1",
-        "7zip-bin-mac": "1.0.1",
-        "7zip-bin-win": "2.2.0"
+        "7zip-bin-mac": "1.0.1"
       }
-    },
-    "7zip-bin-linux": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-      "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-      "dev": true,
-      "optional": true
     },
     "7zip-bin-mac": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
       "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-      "dev": true,
-      "optional": true
-    },
-    "7zip-bin-win": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.2.0.tgz",
-      "integrity": "sha512-uPHXapEmUtlUKTBx4asWMlxtFUWXzEY0KVEgU7QKhgO2LJzzM3kYxM6yOyUZTtYE6mhK4dDn3FDut9SCQWHzgg==",
       "dev": true,
       "optional": true
     },
@@ -178,29 +162,13 @@
       "integrity": "sha512-2T76qAMufe5qfsyIAcrx1hofxPXDXyHQdLG1LBJg6H0ii1ooDz5/RMIhuvp2i4ULm0eNzLOASjtDKZqRlqa41g==",
       "dev": true,
       "requires": {
-        "app-builder-bin-linux": "1.3.5",
-        "app-builder-bin-mac": "1.3.5",
-        "app-builder-bin-win": "1.3.5"
+        "app-builder-bin-mac": "1.3.5"
       }
-    },
-    "app-builder-bin-linux": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/app-builder-bin-linux/-/app-builder-bin-linux-1.3.5.tgz",
-      "integrity": "sha512-JXg95NUFD/EOpYoZ/SQxmiJQrFBe0vAtt9hblMp4LGhGoDL2rY7PKCNMUrpwSTueGeHY67WW4dLjc1xXBQ86aA==",
-      "dev": true,
-      "optional": true
     },
     "app-builder-bin-mac": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/app-builder-bin-mac/-/app-builder-bin-mac-1.3.5.tgz",
       "integrity": "sha512-mix/uEXYmwnoK8CrrLPZR5gHuGyZsOyiQXsikwrKKgcH+gscawc280CRYwsOqviI+lvFWR7lGIuJy2/wb4w1dA==",
-      "dev": true,
-      "optional": true
-    },
-    "app-builder-bin-win": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/app-builder-bin-win/-/app-builder-bin-win-1.3.5.tgz",
-      "integrity": "sha512-9CGmgMv5og+NOR8Ai867iD3qGOL4aVSHjQL/Ii9XvzxJZg/yvCC8fWCk4/Lr2sVUmupO53ZJ0+C35OsAbx1yDQ==",
       "dev": true,
       "optional": true
     },
@@ -436,9 +404,9 @@
       }
     },
     "bignumber.js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+      "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
     },
     "binary-search-tree": {
       "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   "dependencies": {
     "apollo-server-restify": "^1.3.2",
     "babel-polyfill": "^6.26.0",
+    "bignumber.js": "^6.0.0",
     "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -29,7 +29,17 @@ function getContractMetadata(versionNum = Config.CONTRACT_VERSION_NUM, testnet =
   return mainnetMetadata[versionNum];
 }
 
+function getBlockChainConstants(testnet=Config.TESTNET) {
+  const BLOCK_0_TIMESTAMP = 1504695029; // same for testnet & mainnet
+
+  return {
+    BLOCK_0_TIMESTAMP,
+  }
+
+}
+
 module.exports = {
   Config,
   getContractMetadata,
+  getBlockChainConstants,
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -12,10 +12,6 @@ const Config = {
   TESTNET: true,
 };
 
-const BlockChainConstants = {
-  BLOCK_0_TIMESTAMP: 1504695029,
-}
-
 /*
 * Gets the smart contract metadata based on version and environment.
 * @param versionNum {Number} The version number of the contracts to get, ie. 0, 1, 2.
@@ -35,6 +31,5 @@ function getContractMetadata(versionNum = Config.CONTRACT_VERSION_NUM, testnet =
 
 module.exports = {
   Config,
-  BlockChainConstants,
   getContractMetadata,
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -12,6 +12,10 @@ const Config = {
   TESTNET: true,
 };
 
+const BlockChainConstants = {
+  BLOCK_0_TIMESTAMP: 1504695029,
+}
+
 /*
 * Gets the smart contract metadata based on version and environment.
 * @param versionNum {Number} The version number of the contracts to get, ie. 0, 1, 2.
@@ -29,17 +33,8 @@ function getContractMetadata(versionNum = Config.CONTRACT_VERSION_NUM, testnet =
   return mainnetMetadata[versionNum];
 }
 
-function getBlockChainConstants(testnet=Config.TESTNET) {
-  const BLOCK_0_TIMESTAMP = 1504695029; // same for testnet & mainnet
-
-  return {
-    BLOCK_0_TIMESTAMP,
-  }
-
-}
-
 module.exports = {
   Config,
+  BlockChainConstants,
   getContractMetadata,
-  getBlockChainConstants,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,7 @@ module.exports = {
     SUCCESS: 'SUCCESS',
     FAIL: 'FAIL',
   },
+
+  BLOCK_0_TIMESTAMP: 1504695029,
+  SATOSHI_CONVERSION: 10 ** 8,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const logger = require('./utils/logger');
 const schema = require('./schema');
 const syncRouter = require('./route/sync');
 const apiRouter = require('./route/api');
-const startSync = require('./sync');
+const { startSync } = require('./sync');
 const Utils = require('./utils/utils');
 
 const qClient = new Qweb3(Config.QTUM_RPC_ADDRESS);

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -86,6 +86,7 @@ type syncInfo {
   syncBlockNum: Int
   syncBlockTime: String
   syncPercent: Int
+  addressBalances: [AddressBalance]!
 }
 
 type Query {
@@ -94,7 +95,7 @@ type Query {
   searchOracles(searchPhrase: String, orderBy: [Order!], limit: Int, skip: Int): [Oracle]!
   allVotes(filter: VoteFilter, orderBy: [Order!], limit: Int, skip: Int): [Vote]!
   allTransactions(filter: TransactionFilter, orderBy: [Order!], limit: Int, skip: Int): [Transaction]!
-  syncInfo: syncInfo!
+  syncInfo(includeBalance: Boolean): syncInfo!
 }
 
 input TopicFilter {
@@ -209,6 +210,12 @@ input Order {
 type TopicSubscriptionPayload {
   mutation: _ModelMutationType!
   node: Topic
+}
+
+type AddressBalance {
+  address: String!,
+  qtum: String!,
+  bot: String!,
 }
 
 enum _ModelMutationType {

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -85,7 +85,7 @@ type Block {
 type syncInfo {
   syncBlockNum: Int
   syncBlockTime: String
-  chainBlockNum: Int
+  syncPercent: Int
 }
 
 type Query {

--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -16,7 +16,7 @@ const decentralizedOracle = require('../api/decentralized_oracle');
 const DBHelper = require('../db/nedb').DBHelper;
 const { Config } = require('../config/config');
 const { txState } = require('../constants');
-const { calculateSyncPercent } = require('../sync');
+const { calculateSyncPercent, listUnspentBalance } = require('../sync');
 
 const DEFAULT_LIMIT_NUM = 50;
 const DEFAULT_SKIP_NUM = 0;
@@ -242,7 +242,8 @@ module.exports = {
       return cursor.exec();
     },
 
-    syncInfo: async (root, {}, { db: { Blocks } }) => {
+    syncInfo: async (root, { includeBalance }, { db: { Blocks } }) => {
+      const fetchBalance = includeBalance || false;
       let syncBlockNum = null;
       let syncBlockTime = null;
       let syncPercent = null;
@@ -259,7 +260,18 @@ module.exports = {
         syncPercent = calculateSyncPercent(syncBlockTime);
       }
 
-      return { syncBlockNum, syncBlockTime, syncPercent };
+      let addressBalances = [];
+      if (fetchBalance) {
+        addressBalances = await listUnspentBalance();
+      }
+
+
+      return {
+        syncBlockNum,
+        syncBlockTime,
+        syncPercent,
+        addressBalances,
+      };
     },
   },
 


### PR DESCRIPTION
1. Fix #131 
add syncPercent in /syncinfo
syncPercent is calculated by 

```
(blockTime - block_0_Time) / (now - block_0_Time)
```

2. Fix #135 
    add addressbalances array in syncinfo, add includebalance parameter in syncinfo query

![image](https://user-images.githubusercontent.com/2467199/37308518-89480d52-25fb-11e8-903f-8d61972807e9.png)

@dwalintukan Question: current qtum balance comes in float string while bot balance comes as satoshi string, which one does FR prefer?