### PR TITLE
ResetApprove tx fields trim

### DIFF
--- a/src/sync/update_tx.js
+++ b/src/sync/update_tx.js
@@ -274,23 +274,14 @@ async function resetApproveAmount(db, tx, spender) {
 
   await DBHelper.insertTransaction(db.Transactions, {
     txid,
-    version: tx.version,
     type: 'RESETAPPROVE',
     status: txState.PENDING,
     createdTime: moment().unix(),
+    version: tx.version,
     senderAddress: tx.senderAddress,
     topicAddress: tx.topicAddress,
     oracleAddress: tx.oracleAddress,
     name: tx.name,
-    options: tx.options,
-    optionIdx: tx.optionIdx,
-    resultSetterAddress: tx.resultSetterAddress,
-    bettingStartTime: tx.bettingStartTime,
-    bettingEndTime: tx.bettingEndTime,
-    resultSettingStartTime: tx.resultSettingStartTime,
-    resultSettingEndTime: tx.resultSettingEndTime,
-    token: 'BOT',
-    amount: tx.amount,
   });
 }
 


### PR DESCRIPTION
See: https://github.com/bodhiproject/bodhi-ui/issues/431
Depends on: https://github.com/bodhiproject/bodhi-ui/pull/438

`RESETAPPROVE` txs don't need all the extra info as part of the tx. Otherwise it shows up as extra info in the UI tx history.

See the first tx here, doesn't need to show 100 BOT.
![image](https://user-images.githubusercontent.com/4350404/38082212-348a64fe-3370-11e8-9304-fa43723efca7.png)
