### PR TITLE
Sync percent fix

### DIFF
--- a/src/api/blockchain.js
+++ b/src/api/blockchain.js
@@ -27,6 +27,18 @@ const Blockchain = {
     return qClient.getBlockCount();
   },
 
+  async getBlockHash(args) {
+    const {
+      blockNum, // string
+    } = args;
+
+    if (_.isUndefined(blockNum)) {
+      throw new TypeError('blockNum needs to be defined');
+    }
+
+    return qClient.getBlockHash(blockNum);
+  },
+
   async getTransactionReceipt(args) {
     const {
       transactionId, // string

--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -273,15 +273,17 @@ module.exports = {
       //   syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
       // }
 
-      const currentBlockCount = Math.max(0, await qclient.getBlockCount());
-      const currentBlockHash = await qclient.getBlockHash(currentBlockCount);
-      const currentBlockTime = (await qclient.getBlock(currentBlockHash)).time;
+      const syncBlockNum = Math.max(0, await blockchain.getBlockCount());
+      const blockHash = await blockchain.getBlockHash({ blockNum: syncBlockNum });
+      const syncBlockTime = (await blockchain.getBlock({ blockHash })).time;
       const syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
 
       let addressBalances = [];
       if (fetchBalance) {
         addressBalances = await getAddressBalances();
       }
+
+      console.log(`blockNum: ${syncBlockNum} blockTime: ${syncBlockTime} syncPercent: ${syncPercent}`);
 
       return {
         syncBlockNum,

--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -277,9 +277,8 @@ module.exports = {
       }
       const syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
 
-      const fetchBalance = includeBalance || false;
       let addressBalances = [];
-      if (fetchBalance) {
+      if (includeBalance || false) {
         addressBalances = await getAddressBalances();
       }
 

--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -257,22 +257,6 @@ module.exports = {
 
     syncInfo: async (root, { includeBalance }, { db: { Blocks } }) => {
       const fetchBalance = includeBalance || false;
-      // let syncBlockNum = null;
-      // let syncBlockTime = null;
-      // let syncPercent = null;
-      // let blocks;
-      // try {
-      //   blocks = await Blocks.cfind({}).sort({ blockNum: -1 }).limit(1).exec();
-      // } catch (err) {
-      //   logger.error(`Error query latest block from db: ${err.message}`);
-      // }
-
-      // if (blocks.length > 0) {
-      //   syncBlockNum = blocks[0].blockNum;
-      //   syncBlockTime = blocks[0].blockTime;
-      //   syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
-      // }
-
       const syncBlockNum = Math.max(0, await blockchain.getBlockCount());
       const blockHash = await blockchain.getBlockHash({ blockNum: syncBlockNum });
       const syncBlockTime = (await blockchain.getBlock({ blockHash })).time;
@@ -282,8 +266,6 @@ module.exports = {
       if (fetchBalance) {
         addressBalances = await getAddressBalances();
       }
-
-      console.log(`blockNum: ${syncBlockNum} blockTime: ${syncBlockTime} syncPercent: ${syncPercent}`);
 
       return {
         syncBlockNum,

--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 
 const pubsub = require('../pubsub');
 const logger = require('../utils/logger');
+const blockchain = require('../api/blockchain');
 const wallet = require('../api/wallet');
 const bodhiToken = require('../api/bodhi_token');
 const eventFactory = require('../api/event_factory');
@@ -256,21 +257,26 @@ module.exports = {
 
     syncInfo: async (root, { includeBalance }, { db: { Blocks } }) => {
       const fetchBalance = includeBalance || false;
-      let syncBlockNum = null;
-      let syncBlockTime = null;
-      let syncPercent = null;
-      let blocks;
-      try {
-        blocks = await Blocks.cfind({}).sort({ blockNum: -1 }).limit(1).exec();
-      } catch (err) {
-        logger.error(`Error query latest block from db: ${err.message}`);
-      }
+      // let syncBlockNum = null;
+      // let syncBlockTime = null;
+      // let syncPercent = null;
+      // let blocks;
+      // try {
+      //   blocks = await Blocks.cfind({}).sort({ blockNum: -1 }).limit(1).exec();
+      // } catch (err) {
+      //   logger.error(`Error query latest block from db: ${err.message}`);
+      // }
 
-      if (blocks.length > 0) {
-        syncBlockNum = blocks[0].blockNum;
-        syncBlockTime = blocks[0].blockTime;
-        syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
-      }
+      // if (blocks.length > 0) {
+      //   syncBlockNum = blocks[0].blockNum;
+      //   syncBlockTime = blocks[0].blockTime;
+      //   syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
+      // }
+
+      const currentBlockCount = Math.max(0, await qclient.getBlockCount());
+      const currentBlockHash = await qclient.getBlockHash(currentBlockCount);
+      const currentBlockTime = (await qclient.getBlock(currentBlockHash)).time;
+      const syncPercent = await calculateSyncPercent(syncBlockNum, syncBlockTime);
 
       let addressBalances = [];
       if (fetchBalance) {

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -543,8 +543,7 @@ async function calculateSyncPercent(blockCount, blockTime) {
     return syncPercent;
   }
 
-  console.log(`blockCount: ${blockCount} peerBlockHeader: ${peerBlockHeader}`);
-  return Math.floor(blockCount / peerBlockHeader) * 100;
+  return Math.floor(blockCount / peerBlockHeader * 100);
 }
 
 // Send syncInfo subscription

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -543,6 +543,7 @@ async function calculateSyncPercent(blockCount, blockTime) {
     return syncPercent;
   }
 
+  console.log(`blockCount: ${blockCount} peerBlockHeader: ${peerBlockHeader}`);
   return Math.floor(blockCount / peerBlockHeader) * 100;
 }
 


### PR DESCRIPTION
This fixes the sync percent not returning correctly. Couple of things:
1. `Math.floor(blockCount / peerBlockHeader) * 100` was returning 0 all the time cause blockCount / peerBlockHeader would be a decimal number then rounded to 0.

2. syncInfo query was comparing synced blocks in DB to get blockCount/time for calculateSyncPercent. This was incorrect because it does not take into account for fresh blockchains.

ie. if contractStartBlockNum = 100000, then blocks don't get inserted until the qtum blockchain data is at least 100000. then the syncInfo query would always return null because it was using the last synced block. so user doesn't see any sync percentage from 0 - 100000.

Changed it so it fetches the current block num and time from syncing blockchain. This is the same logic as the sync logic for the syncInfo subscription.