### PR TITLE
Versioning schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Bodhi",
-  "version": "0.6.4",
+  "version": "0.6.5-0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Bodhi",
-  "version": "0.6.5-0-0",
+  "version": "0.6.5-c0-d0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Bodhi Prediction Market app",
   "author": "bodhi.network",
   "license": "ISC",
-  "version": "0.6.5-0-0",
+  "version": "0.6.5-c0-d0",
   "repository": "git@github.com:bodhiproject/bodhi-graphql.git",
   "main": "main.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Bodhi Prediction Market app",
   "author": "bodhi.network",
   "license": "ISC",
-  "version": "0.6.5",
+  "version": "0.6.5-0-0",
   "repository": "git@github.com:bodhiproject/bodhi-graphql.git",
   "main": "main.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Bodhi Prediction Market app",
   "author": "bodhi.network",
   "license": "ISC",
-  "version": "0.6.4",
+  "version": "0.0.6.5",
   "repository": "git@github.com:bodhiproject/bodhi-graphql.git",
   "main": "main.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Bodhi Prediction Market app",
   "author": "bodhi.network",
   "license": "ISC",
-  "version": "0.0.6.5",
+  "version": "0.6.5",
   "repository": "git@github.com:bodhiproject/bodhi-graphql.git",
   "main": "main.js",
   "keywords": [

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -25,8 +25,8 @@ class Utils {
       }
       // Example: 0.6.5-c0-d1
       // c0 = contract version 0, d1 = db version 1
-      const patchVersionArr = version.substr(lastPeriodIndex + 1).split('-'); // ie. 5-c0-d1
-      const versionDir = `${patchVersionArr[1]}.${patchVersionArr[2]}` // ie. c0.d1
+      const patchVersionArr = version.substr(lastPeriodIndex + 1).split('-'); // 5-c0-d1
+      const versionDir = `${patchVersionArr[1]}.${patchVersionArr[2]}` // c0.d1
 
       // production
       dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,7 +23,10 @@ class Utils {
       if (lastPeriodIndex === -1) {
         throw new Error(`Invalid version number: ${version}`);
       }
-      const versionDir = version.substr(0, lastPeriodIndex);
+      // Example: 0.6.5-c0-d1
+      // c0 = contract version 0, d1 = db version 1
+      const patchVersionArr = version.substr(lastPeriodIndex + 1).split('-'); // ie. 5-c0-d1
+      const versionDir = `${patchVersionArr[1]}.${patchVersionArr[2]}` // ie. c0.d1
 
       // production
       dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -19,13 +19,14 @@ class Utils {
     if (_.indexOf(process.argv, '--dev') === -1) {
       const pathPrefix = Config.TESTNET ? 'testnet' : 'mainnet';
 
-      const regexMatches = version.exec(/(\d+)\.(\d+)\.(\d+)-(c\d+)-(d\d+)/g);
-      if (regexMatches === null) {
+      const regex = RegExp(/(\d+)\.(\d+)\.(\d+)-(c\d+)-(d\d+)/g);
+      const regexGroups = regex.exec(version);
+      if (regexGroups === null) {
         throw new Error(`Invalid version number: ${version}`);
       }
       // Example: 0.6.5-c0-d1
       // c0 = contract version 0, d1 = db version 1
-      const versionDir = `${regexMatches[3]}_${regexMatches[4]}` // c0_d1
+      const versionDir = `${regexMatches[4]}_${regexMatches[5]}` // c0_d1
 
       // production
       dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -26,7 +26,7 @@ class Utils {
       // Example: 0.6.5-c0-d1
       // c0 = contract version 0, d1 = db version 1
       const patchVersionArr = version.substr(lastPeriodIndex + 1).split('-'); // 5-c0-d1
-      const versionDir = `${patchVersionArr[1]}.${patchVersionArr[2]}` // c0.d1
+      const versionDir = `${patchVersionArr[1]}_${patchVersionArr[2]}` // c0_d1
 
       // production
       dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -19,14 +19,13 @@ class Utils {
     if (_.indexOf(process.argv, '--dev') === -1) {
       const pathPrefix = Config.TESTNET ? 'testnet' : 'mainnet';
 
-      const lastPeriodIndex = _.lastIndexOf(version, ".");
-      if (lastPeriodIndex === -1) {
+      const regexMatches = version.exec(/(\d+)\.(\d+)\.(\d+)-(c\d+)-(d\d+)/g);
+      if (regexMatches === null) {
         throw new Error(`Invalid version number: ${version}`);
       }
       // Example: 0.6.5-c0-d1
       // c0 = contract version 0, d1 = db version 1
-      const patchVersionArr = version.substr(lastPeriodIndex + 1).split('-'); // 5-c0-d1
-      const versionDir = `${patchVersionArr[1]}_${patchVersionArr[2]}` // c0_d1
+      const versionDir = `${regexMatches[3]}_${regexMatches[4]}` // c0_d1
 
       // production
       dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -4,6 +4,7 @@ const { app } = require('electron');
 const Web3Utils = require('web3-utils');
 
 const { Config } = require('../config/config');
+const { version } = require('../../package.json');
 
 const DIR_DEV = 'dev';
 
@@ -16,12 +17,16 @@ class Utils {
 
     let dataDir;
     if (_.indexOf(process.argv, '--dev') === -1) {
-      const version = Config.CONTRACT_VERSION_NUM;
-      const testnet = Config.TESTNET;
-      const pathPrefix = testnet ? 'testnet' : 'mainnet';
+      const pathPrefix = Config.TESTNET ? 'testnet' : 'mainnet';
+
+      const lastPeriodIndex = _.lastIndexOf(version, ".");
+      if (lastPeriodIndex === -1) {
+        throw new Error(`Invalid version number: ${version}`);
+      }
+      const versionDir = version.substr(0, lastPeriodIndex);
 
       // production
-      dataDir = `${osDataDir}/${pathPrefix}/${version}`;
+      dataDir = `${osDataDir}/${pathPrefix}/${versionDir}`;
     } else {
       // development
       dataDir = `${osDataDir}/${DIR_DEV}`;


### PR DESCRIPTION
Tried many ways to add a 4th version code, but it does not seem to accept it for the Node semantic versioning system.

I've appended the contract and db version to the patch version number:
`0.6.5-c0-d0` where c# is the contract version and d# is the db version.